### PR TITLE
Add bash GTFOBIN file upload rule

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_bash_fileupload.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_bash_fileupload.yml
@@ -1,0 +1,25 @@
+title: Suspicious Bash File Upload - Linux
+id: f30e0410-65be-4f85-b1cf-ba0b51f25b51
+status: experimental
+description: Bash file redirection to a network protocol pseudo-device
+references:
+    - https://gtfobins.github.io/gtfobins/bash/#file-upload
+tags:
+    - attack.exfiltration
+    - attack.t1567
+author: Seth Hanford (LinkedIn)
+date: 2025-08-20
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        Image|endswith: '/bash'
+        CommandLine|contains|all:
+            - 'c'
+            - '>'
+        CommandLine|re: '/dev/(tc|ud)p/'
+    condition: selection
+falsepositives:
+    - Legitimate redirection via bash to /dev/tcp or /dev/udp
+level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_bash_fileupload.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_bash_fileupload.yml
@@ -5,21 +5,24 @@ description: Bash file redirection to a network protocol pseudo-device
 references:
     - https://gtfobins.github.io/gtfobins/bash/#file-upload
 tags:
+    - attack.execution
     - attack.exfiltration
     - attack.t1567
+    - attack.t1059.004
 author: Seth Hanford (LinkedIn)
 date: 2025-08-20
 logsource:
     category: process_creation
     product: linux
 detection:
-    selection:
+    selection_bash_output_redir:
         Image|endswith: '/bash'
-        CommandLine|contains|all:
-            - 'c'
-            - '>'
-        CommandLine|re: '/dev/(tc|ud)p/'
-    condition: selection
+        CommandLine|contains: '>'
+    selection_dvcs:
+        CommandLine|contains:
+            - '/dev/tcp'
+            - '/dev/udp'
+    condition: all of selection*
 falsepositives:
     - Legitimate redirection via bash to /dev/tcp or /dev/udp
 level: medium


### PR DESCRIPTION
Detect outbound rediretion via bash to /dev/tcp or /dev/udp, which is indicative of outbound communication via builtin bash pseudo-devices